### PR TITLE
Align checkboxes and text

### DIFF
--- a/style.css
+++ b/style.css
@@ -90,12 +90,6 @@ a{
     margin: 0;
 }
 
-#disabledslots span{
-	width: 16px;
-	height: 16px;
-    display: inline-block;
-}
-
 #disabledslots .sprite{
     background-repeat: no-repeat;
     background-image: url("images/slots.png");

--- a/style.css
+++ b/style.css
@@ -62,10 +62,32 @@ a{
 }
 
 #disabledslots .first{
-	width: 60px;
-	display: inline-block;
-	clear: left;
-	text-align: right;
+    width: 60px;
+    display: inline-block;
+    clear: left;
+    text-align: right;
+    vertical-align: top;
+}
+
+#disabledslots span{
+    width: 16px;
+    height: 16px;
+    display: inline-block;
+}
+
+#disabledslots div{
+    height: 16px;
+    line-height: 16px;
+}
+
+#disabledslots div + div{
+    margin-top: 4px;
+}
+
+#disabledslots input[type=checkbox]{
+    width: 16px;
+    height: 16px;
+    margin: 0;
 }
 
 #disabledslots span{


### PR DESCRIPTION
It currently looks like this:
![image](https://cloud.githubusercontent.com/assets/7348146/10122272/aaa2c682-6513-11e5-93ef-492a5e625a6b.png)
With this commit it will look like this:
![image](https://cloud.githubusercontent.com/assets/7348146/10122267/8b549abc-6513-11e5-8626-0dbe3ffed979.png)

I have tested this in Chrome, IE and Edge. You can see a preview in your browser [here](https://cdn.rawgit.com/metarmask/Minecraft-ArmorStand/patch-1/index.htm).