### PR TITLE
fixed leather armor color not applying if there were no boots

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -485,14 +485,14 @@ function getShoesItem(){
 function getLeggingsItem(){
 	if(equipLeggings == "") return "{}";
 	return "{id:\""+equipLeggings+"\",Count:1b"
-					+getLeatherColorString($("#leggingscolor"), isLeatherArmor(equipShoes))
+					+getLeatherColorString($("#leggingscolor"), isLeatherArmor(equipLeggings))
 					+"}";
 }
 
 function getChestplateItem(){
 	if(equipChestplate == "") return "{}";
 	return "{id:\""+equipChestplate+"\",Count:1b"
-				+getLeatherColorString($("#chestplatecolor"), isLeatherArmor(equipShoes))
+				+getLeatherColorString($("#chestplatecolor"), isLeatherArmor(equipChestplate))
 				+"}";
 }
 
@@ -502,7 +502,7 @@ function getHeadItem(){
 	// Use input as item
 	if(equipCustomHeadMode == "item"){
 		return "{id:\""+equipHelmet+"\",Count:1b"
-		+getLeatherColorString($("#helmetcolor"), isLeatherArmor(equipShoes))
+		+getLeatherColorString($("#helmetcolor"), isLeatherArmor(equipHelmet))
 		+"}";
 	}
 


### PR DESCRIPTION
There was a typo in js/main.js when the summon command was generated, it was calling equipShoes all armor types, instead of equipLeggings, equipChestplate, etc